### PR TITLE
Bump alpine from 3.16.0 to 3.17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16.0
+FROM alpine:3.17.1
 LABEL maintainer="JulianPrieber"
 LABEL description="LittleLink Custom Docker"
 


### PR DESCRIPTION
Bumps alpine from 3.16.0 to 3.17.1.

---
updated-dependencies:
- dependency-name: alpine dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>